### PR TITLE
TypeError fix, when there is no ref

### DIFF
--- a/src/use-measure.ts
+++ b/src/use-measure.ts
@@ -18,6 +18,10 @@ export default function useMeasure(ref: RefObject<HTMLElement | null>) {
   );
 
   useLayoutEffect(() => {
+    if (ref.current === null) {
+      return;
+    }
+    
     let animationFrameId : number | null = null;
     const measure: ResizeObserverCallback = ([entry]) => {
       animationFrameId = window.requestAnimationFrame(() => {


### PR DESCRIPTION
Fixes TypeError: Failed to execute 'observe' on 'ResizeObserver': parameter 1 is not of type 'Element'.

In case element you're trying to measure is conditional, you would get above error.